### PR TITLE
Deployed to IPFS + IPNS

### DIFF
--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          cache: 'npm'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install dependencies
         run: pnpm install
 

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -8,8 +8,7 @@ permissions:
 on:
   push:
     branches:
-      - jw/ipfs-gateway
-  pull_request:
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -18,15 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Publish to IPNS
         run: |
-          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=self ${{ steps.deploy.outputs.cid }}
+          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=ipns ${{ steps.deploy.outputs.cid }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -40,3 +40,7 @@ jobs:
           kubo-api-url: ${{ secrets.KUBO_API_URL }}
           kubo-api-auth	: ${{ secrets.KUBO_API_AUTH }}
           github-token: ${{ github.token }}
+
+      - name: Update IPNS
+        run: |
+          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish ${{ steps.deploy.outputs.cid }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -43,4 +43,6 @@ jobs:
 
       - name: Publish to IPNS
         run: |
-          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=self ${{ steps.deploy.outputs.cid }}
+          OUTPUT=$(ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=self ${{ steps.deploy.outputs.cid }})
+          echo "$OUTPUT"
+          echo "✅ $OUTPUT" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Publish to IPNS
         run: |
-          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish ${{ steps.deploy.outputs.cid }}
+          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=self ${{ steps.deploy.outputs.cid }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -41,6 +41,6 @@ jobs:
           kubo-api-auth	: ${{ secrets.KUBO_API_AUTH }}
           github-token: ${{ github.token }}
 
-      - name: Update IPNS
+      - name: Publish to IPNS
         run: |
           ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish ${{ steps.deploy.outputs.cid }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -43,4 +43,4 @@ jobs:
 
       - name: Publish to IPNS
         run: |
-          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=ipns ${{ steps.deploy.outputs.cid }}
+          ipfs --api=${{ secrets.KUBO_API_URL }} --api-auth=${{ secrets.KUBO_API_AUTH }} name publish --key=self ${{ steps.deploy.outputs.cid }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '20'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -1,0 +1,40 @@
+name: Deploy to IPFS
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+on:
+  push:
+    branches:
+      - jw/ipfs-gateway
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build project
+        run: pnpm build
+
+      - name: Deploy to IPFS
+        uses: ipfs/ipfs-deploy-action@v1
+        id: deploy
+        with:
+          path-to-deploy: dist
+          kubo-api-url: ${{ secrets.KUBO_API_URL }}
+          kubo-api-auth	: ${{ secrets.KUBO_API_AUTH }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/ipfs.yml
+++ b/.github/workflows/ipfs.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - jw/ipfs-gateway
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ pnpm-debug.log*
 
 # netlify
 .netlify
+
+# ipfs
+ipfs-data
+caddy-data

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,12 +4,12 @@ import tailwindcss from "@tailwindcss/vite";
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
+import relativeLinks from 'astro-relative-links';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://jaydenwindle.com',
-  base: './',
-  integrations: [mdx(), sitemap(), react()],
+  integrations: [mdx(), sitemap(), react(), relativeLinks()],
 
   vite: {
     plugins: [tailwindcss()],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import react from "@astrojs/react";
 // https://astro.build/config
 export default defineConfig({
   site: 'https://jaydenwindle.com',
+  base: './',
   integrations: [mdx(), sitemap(), react()],
 
   vite: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,7 @@ import relativeLinks from 'astro-relative-links';
 export default defineConfig({
   site: 'https://jaydenwindle.com',
   integrations: [mdx(), sitemap(), react(), relativeLinks()],
+  trailingSlash: 'always',
 
   vite: {
     plugins: [tailwindcss()],

--- a/ipfs/.env.example
+++ b/ipfs/.env.example
@@ -1,0 +1,9 @@
+IPFS_TELEMETRY=off
+
+# Domain for the IPFS gateway (required)
+DOMAIN=
+
+# IPFS API authentication token (required)
+# Enables authenticated access to the IPFS RPC API on port 5001 with TLS
+# Generate with: openssl rand -hex 32
+IPFS_API_AUTH_TOKEN=

--- a/ipfs/Caddyfile
+++ b/ipfs/Caddyfile
@@ -1,5 +1,4 @@
-# Main domain - IPFS gateway only
-{$DOMAIN} {
+:8080 {
   reverse_proxy kubo:8080
 
   log {
@@ -9,9 +8,7 @@
   }
 }
 
-# IPFS RPC API on port 5001 with self-signed TLS
 :5001 {
-  tls internal
   reverse_proxy kubo:5001
 
   log {

--- a/ipfs/Caddyfile
+++ b/ipfs/Caddyfile
@@ -1,19 +1,25 @@
-:8080 {
-  reverse_proxy kubo:8080
-
-  log {
+(logging) {
+	log {
     output stdout
     format json
     level INFO
-  }
+	}
+}
+
+{$DOMAIN:localhost} {
+  reverse_proxy kubo:8080
+
+  import logging
+}
+
+:8080 {
+  reverse_proxy kubo:8080
+
+  import logging
 }
 
 :5001 {
   reverse_proxy kubo:5001
 
-  log {
-    output stdout
-    format json
-    level INFO
-  }
+  import logging
 }

--- a/ipfs/Caddyfile
+++ b/ipfs/Caddyfile
@@ -1,0 +1,22 @@
+# Main domain - IPFS gateway only
+{$DOMAIN} {
+  reverse_proxy kubo:8080
+
+  log {
+    output stdout
+    format json
+    level INFO
+  }
+}
+
+# IPFS RPC API on port 5001 with self-signed TLS
+:5001 {
+  tls internal
+  reverse_proxy kubo:5001
+
+  log {
+    output stdout
+    format json
+    level INFO
+  }
+}

--- a/ipfs/Caddyfile
+++ b/ipfs/Caddyfile
@@ -1,9 +1,9 @@
 (logging) {
-	log {
+  log {
     output stdout
     format json
     level INFO
-	}
+  }
 }
 
 {$DOMAIN:localhost} {

--- a/ipfs/Dockerfile
+++ b/ipfs/Dockerfile
@@ -1,0 +1,5 @@
+FROM ipfs/kubo:latest
+
+# Copy initialization script
+COPY init.sh /container-init.d/init.sh
+RUN chmod +x /container-init.d/init.sh

--- a/ipfs/docker-compose.yml
+++ b/ipfs/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   kubo:
     build: .
+    ports:
+      - "4001:4001"
+      - "4001:4001/udp"
     volumes:
       - ./ipfs-data:/data/ipfs
     environment:

--- a/ipfs/docker-compose.yml
+++ b/ipfs/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   kubo:
     build: .
+    restart: unless-stopped
     ports:
       - "4001:4001"
       - "4001:4001/udp"
@@ -12,6 +13,7 @@ services:
 
   caddy:
     image: caddy:latest
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"

--- a/ipfs/docker-compose.yml
+++ b/ipfs/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  kubo:
+    build: .
+    volumes:
+      - ./ipfs-data:/data/ipfs
+    environment:
+      - IPFS_API_AUTH_TOKEN=${IPFS_API_AUTH_TOKEN:?IPFS_API_AUTH_TOKEN is required}
+      - DOMAIN=${DOMAIN:?DOMAIN is required}
+
+  caddy:
+    image: caddy:latest
+    ports:
+      - "80:80"
+      - "443:443"
+      - "5001:5001"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./caddy-data:/data
+    environment:
+      - DOMAIN=${DOMAIN:?DOMAIN is required}
+    depends_on:
+      - kubo

--- a/ipfs/docker-compose.yml
+++ b/ipfs/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "80:80"
       - "443:443"
       - "5001:5001"
+      - "8080:8080"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./caddy-data:/data

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -7,10 +7,23 @@ ipfs config --json Gateway.NoFetch true
 # Disable DNSLink resolution globally
 ipfs config --json Gateway.NoDNSLink true
 
-# Enable DNSLink for yourdomain.com
+# Enable DNSLink for jaydenwindle.com
 ipfs config --json Gateway.PublicGateways '{"jaydenwindle.com": {"NoDNSLink": false, "Paths": []}}'
 
 # Set identity PrivKey from environment variable if provided
 if [ -n "$IPFS_IDENTITY_PRIVKEY" ]; then
   ipfs config Identity.PrivKey "$IPFS_IDENTITY_PRIVKEY"
+fi
+
+# Configure deployer auth for API endpoints if provided
+if [ -n "$IPFS_API_AUTH_TOKEN" ]; then
+  ipfs config --json API.Authorizations '{
+    "deployer": {
+      "AuthSecret": "bearer:'"$IPFS_API_AUTH_TOKEN"'",
+      "AllowedPaths": [
+        "/api/v0/name/publish",
+        "/api/v0/dag/import"
+      ]
+    }
+  }'
 fi

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -7,8 +7,16 @@ ipfs config --json Gateway.NoFetch true
 # Disable DNSLink resolution globally
 ipfs config --json Gateway.NoDNSLink true
 
-# Enable DNSLink for jaydenwindle.com
-ipfs config --json Gateway.PublicGateways '{"jaydenwindle.com": {"NoDNSLink": false, "Paths": []}}'
+# Enable DNSLink for jaydenwindle.com and allow IPFS/IPNS on all domains
+ipfs config --json Gateway.PublicGateways '{
+  "jaydenwindle.com": {
+    "NoDNSLink": false,
+    "Paths": []
+  },
+  "*": {
+    "Paths": ["/ipfs", "/ipns"]
+  }
+}'
 
 # Set identity PrivKey from environment variable if provided
 if [ -n "$IPFS_IDENTITY_PRIVKEY" ]; then

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Disable fetching content for arbitrary CIDs
-ipfs config --json Gateway.NoFetch true
+# ipfs config --json Gateway.NoFetch true
 
 # Disable DNSLink resolution globally
 ipfs config --json Gateway.NoDNSLink true

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -15,13 +15,6 @@ ipfs config --json Gateway.PublicGateways '{
   }
 }'
 
-# Set identity PrivKey from environment variable if provided
-if [ -n "$IPFS_IDENTITY_PRIVKEY" ]; then
-  CONFIG_FILE="${IPFS_PATH:-/data/ipfs}/config"
-  jq --arg key "$IPFS_IDENTITY_PRIVKEY" '.Identity.PrivKey = $key' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"
-  mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-fi
-
 # Configure deployer auth for API endpoints if provided
 if [ -n "$IPFS_API_AUTH_TOKEN" ]; then
   ipfs config --json API.Authorizations '{

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -17,7 +17,7 @@ ipfs config --json Gateway.PublicGateways '{
 
 # Import identity key if file exists
 if [ -f "/data/ipfs/ipfs-identity-key.pem" ]; then
-  ipfs key import self -f pem-pkcs8-cleartext /ipfs-identity-key.pem
+  ipfs key import self -f pem-pkcs8-cleartext /data/ipfs/ipfs-identity-key.pem
 fi
 
 # Configure deployer auth for API endpoints if provided

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -16,7 +16,7 @@ ipfs config --json Gateway.PublicGateways '{
 }'
 
 # Import identity key if file exists
-if [ -f "/ipfs-identity-key.pem" ]; then
+if [ -f "/data/ipfs/ipfs-identity-key.pem" ]; then
   ipfs key import self -f pem-pkcs8-cleartext /ipfs-identity-key.pem
 fi
 

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 
 # Disable fetching content for arbitrary CIDs
 ipfs config --json Gateway.NoFetch true

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -17,7 +17,7 @@ ipfs config --json Gateway.PublicGateways '{
 
 # Import identity key if file exists
 if [ -f "/ipfs-identity-key.pem" ]; then
-  ipfs key import self /ipfs-identity-key.pem --force
+  ipfs key import self -f pem-pkcs8-cleartext /ipfs-identity-key.pem
 fi
 
 # Configure deployer auth for API endpoints if provided

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -15,6 +15,11 @@ ipfs config --json Gateway.PublicGateways '{
   }
 }'
 
+# Import identity key if file exists
+if [ -f "/ipfs-identity-key.pem" ]; then
+  ipfs key import self /ipfs-identity-key.pem --force
+fi
+
 # Configure deployer auth for API endpoints if provided
 if [ -n "$IPFS_API_AUTH_TOKEN" ]; then
   ipfs config --json API.Authorizations '{

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -ex
+
+# Disable fetching content for arbitrary CIDs
+ipfs config --json Gateway.NoFetch true
+
+# Disable DNSLink resolution globally
+ipfs config --json Gateway.NoDNSLink true
+
+# Enable DNSLink for yourdomain.com
+ipfs config --json Gateway.PublicGateways '{"jaydenwindle.com": {"NoDNSLink": false, "Paths": []}}'
+
+# Set identity PrivKey from environment variable if provided
+if [ -n "$IPFS_IDENTITY_PRIVKEY" ]; then
+  ipfs config Identity.PrivKey "$IPFS_IDENTITY_PRIVKEY"
+fi

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -12,9 +12,6 @@ ipfs config --json Gateway.PublicGateways '{
   "jaydenwindle.com": {
     "NoDNSLink": false,
     "Paths": []
-  },
-  "*": {
-    "Paths": ["/ipfs", "/ipns"]
   }
 }'
 
@@ -30,6 +27,7 @@ if [ -n "$IPFS_API_AUTH_TOKEN" ]; then
       "AuthSecret": "bearer:'"$IPFS_API_AUTH_TOKEN"'",
       "AllowedPaths": [
         "/api/v0/name/publish",
+        "/api/v0/name/resolve",
         "/api/v0/dag/import"
       ]
     }

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -17,7 +17,9 @@ ipfs config --json Gateway.PublicGateways '{
 
 # Set identity PrivKey from environment variable if provided
 if [ -n "$IPFS_IDENTITY_PRIVKEY" ]; then
-  ipfs config Identity.PrivKey "$IPFS_IDENTITY_PRIVKEY"
+  CONFIG_FILE="${IPFS_PATH:-/data/ipfs}/config"
+  jq --arg key "$IPFS_IDENTITY_PRIVKEY" '.Identity.PrivKey = $key' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"
+  mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
 fi
 
 # Configure deployer auth for API endpoints if provided

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -16,8 +16,8 @@ ipfs config --json Gateway.PublicGateways '{
 }'
 
 # Import identity key if file exists
-if [ -f "/data/ipfs/ipfs-identity-key.pem" ]; then
-  ipfs key import self -f pem-pkcs8-cleartext /data/ipfs/ipfs-identity-key.pem
+if [ -f "/data/ipfs/ipns-key.pem" ]; then
+  ipfs key import ipns -f pem-pkcs8-cleartext /data/ipfs/ipns-key.pem
 fi
 
 # Configure deployer auth for API endpoints if provided

--- a/ipfs/init.sh
+++ b/ipfs/init.sh
@@ -2,34 +2,27 @@
 set -e
 
 # Disable fetching content for arbitrary CIDs
-# ipfs config --json Gateway.NoFetch true
+ipfs config --json Gateway.NoFetch true
 
 # Disable DNSLink resolution globally
 ipfs config --json Gateway.NoDNSLink true
 
-# Enable DNSLink for jaydenwindle.com and allow IPFS/IPNS on all domains
+# Enable DNSLink for domain
 ipfs config --json Gateway.PublicGateways '{
-  "jaydenwindle.com": {
+  "'"$DOMAIN"'": {
     "NoDNSLink": false,
     "Paths": []
   }
 }'
 
-# Import identity key if file exists
-if [ -f "/data/ipfs/ipns-key.pem" ]; then
-  ipfs key import ipns -f pem-pkcs8-cleartext /data/ipfs/ipns-key.pem
-fi
-
-# Configure deployer auth for API endpoints if provided
-if [ -n "$IPFS_API_AUTH_TOKEN" ]; then
-  ipfs config --json API.Authorizations '{
-    "deployer": {
-      "AuthSecret": "bearer:'"$IPFS_API_AUTH_TOKEN"'",
-      "AllowedPaths": [
-        "/api/v0/name/publish",
-        "/api/v0/name/resolve",
-        "/api/v0/dag/import"
-      ]
-    }
-  }'
-fi
+# Configure auth for API endpoints
+ipfs config --json API.Authorizations '{
+  "deployer": {
+    "AuthSecret": "bearer:'"$IPFS_API_AUTH_TOKEN"'",
+    "AllowedPaths": [
+      "/api/v0/name/publish",
+      "/api/v0/name/resolve",
+      "/api/v0/dag/import"
+    ]
+  }
+}'

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource/ibm-plex-serif": "^5.2.7",
     "@tailwindcss/vite": "^4.1.13",
     "astro": "^5.15.1",
+    "astro-relative-links": "^0.4.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       astro:
         specifier: ^5.15.1
         version: 5.15.1(@netlify/blobs@10.2.1)(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
+      astro-relative-links:
+        specifier: ^0.4.2
+        version: 0.4.2(astro@5.15.1(@netlify/blobs@10.2.1)(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1))
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -1379,6 +1382,11 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  astro-relative-links@0.4.2:
+    resolution: {integrity: sha512-YXwnmZz47yxiIIxWR10LwpGlqvGTERJ7JWX2lFRINTg/sFaPkqTx9xNM50W1+9FNMMxtTn7C8YNW5yDVX33Vzw==}
+    peerDependencies:
+      astro: '>=3.0.0'
 
   astro@5.15.1:
     resolution: {integrity: sha512-VM679M1qxOjGo6q3vKYDNDddkALGgMopG93IwbEXd3Buc2xVLuuPj4HNziNugSbPQx5S6UReMp5uzw10EJN81A==}
@@ -5441,6 +5449,11 @@ snapshots:
   ast-module-types@6.0.1: {}
 
   astring@1.9.0: {}
+
+  astro-relative-links@0.4.2(astro@5.15.1(@netlify/blobs@10.2.1)(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)):
+    dependencies:
+      astro: 5.15.1(@netlify/blobs@10.2.1)(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1)
+      glob: 10.4.5
 
   astro@5.15.1(@netlify/blobs@10.2.1)(@types/node@24.3.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.50.1)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:

--- a/src/components/IPFSIndicator.tsx
+++ b/src/components/IPFSIndicator.tsx
@@ -107,7 +107,7 @@ const IPFSIndicator: React.FC = () => {
           href={`https://ipfs.io/ipfs/${cid}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:bg-neutral-100 hover:text-neutral-900"
+          className="hover:bg-neutral-100 hover:text-neutral-900 px-1"
         >
           {truncatedCid}
         </a>

--- a/src/components/IPFSIndicator.tsx
+++ b/src/components/IPFSIndicator.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useEffect } from 'react';
+
+const IPFSIndicator: React.FC = () => {
+  const [cid, setCid] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isResolving, setIsResolving] = useState(false);
+
+  useEffect(() => {
+    // Resolve IPNS name to CID
+    const resolveIPNS = async (ipnsName: string) => {
+      setIsResolving(true);
+      try {
+        // Try to resolve using a public IPFS gateway
+        const response = await fetch(`https://ipfs.io/api/v0/name/resolve?arg=${ipnsName}`);
+        const data = await response.json();
+
+        if (data.Path) {
+          // Extract CID from the resolved path
+          const resolvedCid = data.Path.replace('/ipfs/', '').split('/')[0];
+          setCid(resolvedCid);
+        }
+      } catch (error) {
+        console.error('Error resolving IPNS name:', error);
+      } finally {
+        setIsResolving(false);
+      }
+    };
+
+    // Check if the page is hosted on IPFS by looking for IPFS headers
+    const checkIPFSHost = async () => {
+      try {
+        // Fetch the current page to read headers
+        const response = await fetch(window.location.href, {
+          method: 'HEAD',
+        });
+
+        // Check for x-ipfs-path header (could be /ipfs/CID or /ipns/name)
+        const ipfsPath = response.headers.get('x-ipfs-path');
+
+        // Check for x-ipfs-hash header as fallback
+        const ipfsHashHeader = response.headers.get('x-ipfs-hash');
+
+        if (ipfsPath) {
+          // Parse the IPFS path
+          if (ipfsPath.startsWith('/ipfs/')) {
+            // Direct CID
+            const cidValue = ipfsPath.replace('/ipfs/', '').split('/')[0];
+            setCid(cidValue);
+          } else if (ipfsPath.startsWith('/ipns/')) {
+            // IPNS name - need to resolve it
+            const ipnsValue = ipfsPath.replace('/ipns/', '').split('/')[0];
+            resolveIPNS(ipnsValue);
+          }
+        } else if (ipfsHashHeader) {
+          // Fallback to hash header
+          setCid(ipfsHashHeader);
+        }
+      } catch (error) {
+        console.error('Error checking IPFS headers:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkIPFSHost();
+  }, []);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (!cid && !isResolving) {
+    return null;
+  }
+
+  if (isResolving) {
+    return (
+      <div className="font-mono text-neutral-600 opacity-40 text-center">
+        <span className="text-neutral-500">resolving ipns...</span>
+      </div>
+    );
+  }
+
+  if (cid) {
+    const truncatedCid = `${cid.slice(0, 4)}...${cid.slice(-4)}`;
+
+    return (
+      <div className="font-mono text-neutral-600 opacity-40 text-center w-full">
+        <span>ipfs:</span>{' '}
+        <a
+          href={`https://ipfs.io/ipfs/${cid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-neutral-400 hover:opacity-60"
+        >
+          {truncatedCid}
+        </a>
+      </div>
+    );
+  }
+};
+
+export default IPFSIndicator;

--- a/src/components/IPFSIndicator.tsx
+++ b/src/components/IPFSIndicator.tsx
@@ -41,13 +41,22 @@ const IPFSIndicator: React.FC = () => {
           method: 'HEAD',
         });
 
+        // Check for x-ipfs-roots header first (contains the CID directly)
+        const ipfsRootsHeader = response.headers.get('x-ipfs-roots');
+
         // Check for x-ipfs-path header (could be /ipfs/CID or /ipns/name)
         const ipfsPath = response.headers.get('x-ipfs-path');
 
         // Check for x-ipfs-hash header as fallback
         const ipfsHashHeader = response.headers.get('x-ipfs-hash');
 
-        if (ipfsPath) {
+        if (ipfsRootsHeader) {
+          // Use roots header - take the first CID
+          const rootCid = ipfsRootsHeader.split(',').at(0)?.trim();
+          if (rootCid) {
+            setCid(rootCid);
+          }
+        } else if (ipfsPath) {
           // Parse the IPFS path
           if (ipfsPath.startsWith('/ipfs/')) {
             // Direct CID
@@ -82,7 +91,7 @@ const IPFSIndicator: React.FC = () => {
 
   if (isResolving) {
     return (
-      <div className="font-mono text-neutral-600 opacity-40 text-center">
+      <div className="font-mono text-neutral-700 opacity-40 text-center">
         <span className="text-neutral-500">resolving ipns...</span>
       </div>
     );
@@ -92,7 +101,7 @@ const IPFSIndicator: React.FC = () => {
     const truncatedCid = `${cid.slice(0, 4)}...${cid.slice(-4)}`;
 
     return (
-      <div className="font-mono text-neutral-600 opacity-40 text-center w-full">
+      <div className="font-mono text-neutral-700 opacity-40 text-center w-full">
         <span>ipfs:</span>{' '}
         <a
           href={`https://ipfs.io/ipfs/${cid}`}

--- a/src/components/IPFSIndicator.tsx
+++ b/src/components/IPFSIndicator.tsx
@@ -107,7 +107,7 @@ const IPFSIndicator: React.FC = () => {
           href={`https://ipfs.io/ipfs/${cid}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-neutral-400 hover:opacity-60"
+          className="hover:bg-neutral-100 hover:text-neutral-900"
         >
           {truncatedCid}
         </a>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,7 +2,7 @@
 import "@/styles/global.css";
 import { Font } from 'astro:assets';
 import SEO from "@/components/SEO.astro";
-import IPFSIndicator from "@/components/IPFSIndicator";
+import IPFSIndicator from "@/components/IPFSIndicator.tsx";
 
 export interface Props {
   title: string;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import "@/styles/global.css";
 import { Font } from 'astro:assets';
 import SEO from "@/components/SEO.astro";
+import IPFSIndicator from "@/components/IPFSIndicator";
 
 export interface Props {
   title: string;
@@ -80,14 +81,16 @@ const { title, ...seoProps } = Astro.props;
 				<slot />
 			</main>
 
-			<footer class="flex justify-between pt-16">
-				<p class="font-mono text-neutral-700 opacity-40">
-					c. {new Date().getFullYear()}
-				</p>
+			<footer class="flex justify-between pt-16 text-sm">
+				<div class="flex flex-col gap-1">
+					<p class="font-mono text-neutral-700 opacity-40">
+						c. {new Date().getFullYear()}
+					</p>
+				</div>
 
-				<p class="font-mono text-neutral-600 opacity-40">
-					made with &lt;3
-				</p>
+				<div>
+					<IPFSIndicator client:load />
+				</div>
 			</footer>
 		</div>
 


### PR DESCRIPTION
This PR sets up automated IPFS deployments using the IPFS Deploy Action pointed at a self-hosted Kubo node. It also configures automatic IPNS publishing via an additional Github Action.

Support for IPFS deployments was added to the `astro.config.mjs` using the `astro-relative-links` plugin and `trailingSlash: 'always'` setting. A live IPFS hash display component was added to the website footer. A Docker Compose file was added that configures Kubo for static website hosting and exposes it via Caddy for automatic certificate provisioning.